### PR TITLE
포트폴리오 썸네일 순서 버그 해결

### DIFF
--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioJPARepository.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioJPARepository.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 @Repository
 public interface PortfolioJPARepository extends JpaRepository<Portfolio, Long> {
-    Page<Portfolio> findAll(Pageable pageable);
+    Page<Portfolio> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     void deleteByPlanner(Planner planner);
 

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
@@ -92,9 +92,9 @@ public class PortfolioService {
     }
 
     public List<PortfolioResponse.findAllBy> getPortfolios(PageRequest pageRequest) {
-        List<Portfolio> portfolios = portfolioJPARepository.findAll(pageRequest).getContent();
+        List<Portfolio> portfolios = portfolioJPARepository.findAllByOrderByCreatedAtDesc(pageRequest).getContent();
 
-        List<String> images = imageItemJPARepository.findAllByThumbnailAndPortfolioIn(true, portfolios)
+        List<String> images = imageItemJPARepository.findAllByThumbnailAndPortfolioInOrderByPortfolioCreatedAtDesc(true, portfolios)
                 .stream()
                 .map(ImageEncoder::encode)
                 .toList();

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/image/ImageItemJPARepository.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/image/ImageItemJPARepository.java
@@ -13,7 +13,7 @@ import java.util.List;
 @Repository
 public interface ImageItemJPARepository extends JpaRepository<ImageItem, Long> {
     @EntityGraph("ImageItemWithPortfolio")
-    List<ImageItem> findAllByThumbnailAndPortfolioIn(boolean thumbnail, List<Portfolio> portfolio);
+    List<ImageItem> findAllByThumbnailAndPortfolioInOrderByPortfolioCreatedAtDesc(boolean thumbnail, List<Portfolio> portfolios);
 
     @EntityGraph("ImageItemWithPortfolioAndPlanner")
     List<ImageItem> findByPortfolioId(Long id);

--- a/sunsu-wedding/src/main/resources/db/teardown.sql
+++ b/sunsu-wedding/src/main/resources/db/teardown.sql
@@ -30,11 +30,11 @@ INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`,
 INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('3', '1', '1-3.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
 INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('4', '1', '1-4.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
 INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('5', '1', '1-5.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
-INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('6', '1', '2-1.jpg', '/Users/seokjun/Downloads/images/', '522499', 'true');
-INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('7', '1', '2-2.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
-INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('8', '1', '2-3.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
-INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('9', '1', '2-4.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
-INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('10', '1', '2-5.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
+INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('6', '2', '2-1.jpg', '/Users/seokjun/Downloads/images/', '522499', 'true');
+INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('7', '2', '2-2.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
+INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('8', '2', '2-3.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
+INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('9', '2', '2-4.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
+INSERT INTO imageitem_tb (`id`, `portfolio_id`, `origin_file_name`, `file_path`, `file_size`, `thumbnail`) VALUES  ('10', '2', '2-5.jpg', '/Users/seokjun/Downloads/images/', '522499', 'false');
 
 INSERT INTO match_tb (`id`, `planner_id`, `couple_id`, `status`, `price`, `confirmed_price`, `confirmed_at`, `created_at`, `is_active`) VALUES ('1', '2', '4', 'CONFIRMED', '1000000', '1000000', '2023-10-08 08:30:12.00', '2023-10-08 08:30:12.00', 'true');
 INSERT INTO match_tb (`id`, `planner_id`, `couple_id`, `status`, `price`, `confirmed_price`, `confirmed_at`, `created_at`, `is_active`) VALUES ('2', '2', '4', 'UNCONFIRMED', '1000000', '0', '2023-10-08 08:30:12.00', '2023-10-08 08:30:12.00', 'true');


### PR DESCRIPTION
## 작업 내용
- 포트폴리오 리스트 조회 시에 썸네일 순서가 뒤바뀔 수 있는 버그를 수정하였습니다.
- 포트폴리오 리스트 조회 시에 포트폴리오의 생성날짜를 내림차순 정렬한 결과를 보여줍니다.

## 이슈 번호
close #76 