### PR TITLE
포트폴리오 조회 시 추가 쿼리가 발생하는 버그 수정

### DIFF
--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/Portfolio.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/Portfolio.java
@@ -10,20 +10,20 @@ import org.hibernate.annotations.*;
 
 import java.time.LocalDateTime;
 
-@Getter
-@NoArgsConstructor
 @Entity
-//@OnDelete(action= OnDeleteAction.CASCADE)
+@NoArgsConstructor
+@Getter
 @SQLDelete(sql = "UPDATE portfolio_tb SET is_active = false WHERE id = ?")
 @Where(clause = "is_active = true")
 @Table(name = "portfolio_tb")
+@NamedEntityGraph(name = "PortfolioWithPlanner",
+                  attributeNodes = @NamedAttributeNode("planner"))
 public class Portfolio {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToOne
-    @JoinColumn(name = "planner_id")
     private Planner planner;
 
     @Column(nullable = false)

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioJPARepository.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioJPARepository.java
@@ -3,6 +3,7 @@ package com.kakao.sunsuwedding.portfolio;
 import com.kakao.sunsuwedding.user.planner.Planner;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,6 +13,7 @@ import java.util.Optional;
 
 @Repository
 public interface PortfolioJPARepository extends JpaRepository<Portfolio, Long> {
+    @EntityGraph("PortfolioWithPlanner")
     Page<Portfolio> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     void deleteByPlanner(Planner planner);


### PR DESCRIPTION
## 작업 내용
- 포트폴리오 조회 쿼리를 요청하면 유저 정보 검색으로 인해 발생하는 추가 쿼리를 방지하기 위해 엔티티 그래프를 사용하여 테이블을 join 하였습니다.
- 

## 이슈 번호
close #82 