### PR TITLE
필터링 구현, 토큰 에러 응답 양식 변경

### DIFF
--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/errors/BaseException.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/errors/BaseException.java
@@ -18,9 +18,11 @@ public enum BaseException {
     USER_UNEXPECTED_ERROR("[User] 예상치 못한 문제가 발생했습니다.", 500),
 
     // token 관련
-    ACCESS_TOKEN_EXPIRED("access-token이 만료되었습니다. refresh-token 으로 다시 요청해주세요.", 403),
+    LOGIN_FAIL("로그인 실패. 올바른 정보를 입력해주세요.", 401),
+    ACCESS_TOKEN_EXPIRED("액세스 토큰이 만료되었습니다. 리프레시 토큰으로 다시 요청해주세요.", 403),
+    ACCESS_TOKEN_STILL_ALIVE("액세스 토큰이 아직 유효합니다. 액세스 토큰만 가지고 접근해주세요.", 403),
     ALL_TOKEN_EXPIRED("모든 토큰이 만료되었습니다. 다시 로그인 해야합니다.", 401),
-    TOKEN_NOT_FOUND("토큰을 찾을 수 없습니다.", 404),
+    TOKEN_NOT_FOUND("토큰을 찾을 수 없습니다. 다시 로그인해주세요.", 404),
     TOKEN_NOT_VALID("로그인 토큰이 유효하지 않습니다. 다시 로그인 해주세요", 403),
     TOKEN_REFRESH_FORBIDDEN("토큰을 갱신할 수 없습니다.", 403),
     INVALID_TOKEN_ACCESS_DETECTED("올바르지 않은 접근입니다. 다시 로그인 해주세요.", 403),

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/errors/exception/TokenException.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/errors/exception/TokenException.java
@@ -1,0 +1,19 @@
+package com.kakao.sunsuwedding._core.errors.exception;
+
+import com.kakao.sunsuwedding._core.utils.TokenResponse;
+import com.kakao.sunsuwedding.user.token.ErrorStatus;
+import lombok.Getter;
+
+public class TokenException extends RuntimeException {
+    @Getter
+    String code;
+
+    public TokenException(ErrorStatus status) {
+        super(status.getMessage());
+        this.code = status.getCode();
+    }
+
+    public TokenResponse body() {
+        return TokenResponse.error(this);
+    }
+}

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/security/JwtExceptionFilter.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/security/JwtExceptionFilter.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakao.sunsuwedding._core.errors.BaseException;
 import com.kakao.sunsuwedding._core.errors.exception.ForbiddenException;
 import com.kakao.sunsuwedding._core.errors.exception.NotFoundException;
+import com.kakao.sunsuwedding._core.errors.exception.TokenException;
 import com.kakao.sunsuwedding._core.errors.exception.UnauthorizedException;
 import com.kakao.sunsuwedding._core.utils.FilterResponseUtils;
 import jakarta.servlet.FilterChain;
@@ -35,6 +36,9 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
         try {
             chain.doFilter(request, response);
+        }
+        catch (TokenException tokenException) {
+            filterResponseUtils.tokenError(response, tokenException);
         }
         catch (UnauthorizedException unauthorizedException) {
             filterResponseUtils.unAuthorized(response, unauthorizedException);

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/utils/FilterResponseUtils.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/utils/FilterResponseUtils.java
@@ -3,9 +3,11 @@ package com.kakao.sunsuwedding._core.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kakao.sunsuwedding._core.errors.exception.ForbiddenException;
 import com.kakao.sunsuwedding._core.errors.exception.NotFoundException;
+import com.kakao.sunsuwedding._core.errors.exception.TokenException;
 import com.kakao.sunsuwedding._core.errors.exception.UnauthorizedException;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 
@@ -38,5 +40,9 @@ public class FilterResponseUtils {
 
     public void notFound(HttpServletResponse resp, NotFoundException e) throws IOException {
         responseSetting(resp, e.status(), e.body());
+    }
+
+    public void tokenError(HttpServletResponse response, TokenException tokenException) throws IOException {
+        responseSetting(response, HttpStatus.UNAUTHORIZED, tokenException.body());
     }
 }

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/utils/TokenResponse.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/_core/utils/TokenResponse.java
@@ -1,0 +1,19 @@
+package com.kakao.sunsuwedding._core.utils;
+
+import com.kakao.sunsuwedding._core.errors.exception.TokenException;
+
+public record TokenResponse(
+        boolean success,
+        String response,
+        TokenError error
+) {
+    public record TokenError(String code, String message) {}
+
+    public static TokenResponse error(TokenException tokenException) {
+        return new TokenResponse(
+                false,
+                null,
+                new TokenError(tokenException.getCode(), tokenException.getMessage())
+        );
+    }
+}

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioJPARepository.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioJPARepository.java
@@ -1,9 +1,14 @@
 package com.kakao.sunsuwedding.portfolio;
 
 import com.kakao.sunsuwedding.user.planner.Planner;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -12,7 +17,10 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface PortfolioJPARepository extends JpaRepository<Portfolio, Long> {
+public interface PortfolioJPARepository extends JpaRepository<Portfolio, Long>, JpaSpecificationExecutor<Portfolio> {
+    @EntityGraph("PortfolioWithPlanner")
+    Page<Portfolio> findAll(@NotNull Specification specification, @Nullable Pageable pageable);
+
     @EntityGraph("PortfolioWithPlanner")
     List<Portfolio> findAllByIdLessThanOrderByIdDesc(Long id, Pageable pageable);
 

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioRestController.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioRestController.java
@@ -6,6 +6,7 @@ import com.kakao.sunsuwedding.portfolio.cursor.CursorRequest;
 import com.kakao.sunsuwedding.portfolio.cursor.PageCursor;
 import com.kakao.sunsuwedding.portfolio.image.ImageItemService;
 import com.kakao.sunsuwedding.user.planner.Planner;
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.util.Pair;
@@ -19,7 +20,6 @@ import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/portfolios")
 public class PortfolioRestController {
     private final PortfolioService portfolioService;
     private final ImageItemService imageItemService;
@@ -37,8 +37,10 @@ public class PortfolioRestController {
     }
 
     @GetMapping(value = "")
-    public ResponseEntity<?> getPortfolios(@RequestParam @Min(-2) Long cursor) {
-        CursorRequest cursorRequest = new CursorRequest(cursor, PAGE_SIZE);
+    public ResponseEntity<?> getPortfolios(@RequestParam @Min(-2) Long cursor,
+                                           @RequestParam @Nullable String name,
+                                           @RequestParam @Nullable String location) {
+        CursorRequest cursorRequest = new CursorRequest(cursor, PAGE_SIZE, name, location);
         PageCursor<List<PortfolioResponse.FindAllDTO>> response = portfolioService.getPortfolios(cursorRequest);
 
         return ResponseEntity.ok().body(ApiUtils.success(response));

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
@@ -145,8 +145,12 @@ public class PortfolioService {
     private List<Portfolio> getFilteredPortfoliosByCursor(CursorRequest request, Pageable pageable) {
         Map<String, String> keys = new HashMap<>();
 
-        if (request.name() != null) keys.put("name", request.name());
-        if (request.location() != null) keys.put("location", request.location());
+        if (request.name() != null && !request.name().equals("null")) {
+            keys.put("name", request.name());
+        }
+        if (request.location() != null && !request.location().equals("null")) {
+            keys.put("location", request.location());
+        }
 
         Specification<Portfolio> specification = PortfolioSpecification.findPortfolio(request.key(), keys);
         return portfolioJPARepository.findAll(specification, pageable).getContent();

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
@@ -21,12 +21,16 @@ import com.kakao.sunsuwedding.user.planner.PlannerJPARepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -89,12 +93,17 @@ public class PortfolioService {
     }
 
     public PageCursor<List<PortfolioResponse.FindAllDTO>> getPortfolios(CursorRequest request) {
-        Pageable pageable = PageRequest.ofSize(request.size());
-        List<Portfolio> portfolios = getPortfoliosByCursor(request, pageable);
+        Pageable pageable = PageRequest
+                .ofSize(request.size())
+                .withSort(Sort.by("id").descending());
+        List<Portfolio> portfolios = search(request, pageable);
 
         if (portfolios.isEmpty()) return new PageCursor<>(null, CursorRequest.NONE_KEY);
 
+        // 커서가 1이거나 NONE_KEY 일 경우 null 로 대체)
         Long nextKey = getNextKey(portfolios);
+        if (nextKey.equals(1L) || nextKey.equals(CursorRequest.NONE_KEY)) nextKey = null;
+
         List<ImageItem> imageItems = imageItemJPARepository.findAllByThumbnailAndPortfolioInOrderByPortfolioCreatedAtDesc(true, portfolios);
         List<String> encodedImages = ImageEncoder.encode(portfolios, imageItems);
 
@@ -110,6 +119,16 @@ public class PortfolioService {
                 .orElse(CursorRequest.NONE_KEY);
     }
 
+    private List<Portfolio> search(CursorRequest request, Pageable pageable) {
+        // 필터링 조건이 존재하면 필터링 조회 메서드 호출
+        if (request.name() != null || request.location() != null) {
+            return getFilteredPortfoliosByCursor(request, pageable);
+        }
+
+        // 필터링 조건이 없다면 커서만 가지고 조회
+        return getPortfoliosByCursor(request, pageable);
+    }
+
     private List<Portfolio> getPortfoliosByCursor(CursorRequest request, Pageable pageable) {
         List<Portfolio> portfolios = new ArrayList<>();
 
@@ -121,6 +140,16 @@ public class PortfolioService {
         }
 
         return portfolios;
+    }
+
+    private List<Portfolio> getFilteredPortfoliosByCursor(CursorRequest request, Pageable pageable) {
+        Map<String, String> keys = new HashMap<>();
+
+        if (request.name() != null) keys.put("name", request.name());
+        if (request.location() != null) keys.put("location", request.location());
+
+        Specification<Portfolio> specification = PortfolioSpecification.findPortfolio(request.key(), keys);
+        return portfolioJPARepository.findAll(specification, pageable).getContent();
     }
 
     public PortfolioResponse.FindByIdDTO getPortfolioById(Long id) {

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioSpecification.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioSpecification.java
@@ -1,0 +1,32 @@
+package com.kakao.sunsuwedding.portfolio;
+
+import com.kakao.sunsuwedding.portfolio.cursor.CursorRequest;
+import jakarta.persistence.criteria.Predicate;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PortfolioSpecification {
+    public static Specification<Portfolio> findPortfolio(Long cursor, Map<String, String> keys) {
+        return ((root, query, criteriaBuilder) -> {
+            // 조건절을 담을 배열
+            List<Predicate> predicates = new ArrayList<>();
+
+            // 시작 커서라면 id 조건은 제외
+            if (!cursor.equals(CursorRequest.START_KEY)) {
+                predicates.add(criteriaBuilder.lessThan(root.get("id"), cursor));
+            }
+
+            // 필터 조건 추가
+            keys.keySet().forEach(key -> {
+                predicates.add(
+                        criteriaBuilder.equal(root.get(key), keys.get(key))
+                );
+            });
+
+            return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+        });
+    }
+}

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/cursor/CursorRequest.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/cursor/CursorRequest.java
@@ -1,6 +1,11 @@
 package com.kakao.sunsuwedding.portfolio.cursor;
 
-public record CursorRequest(Long key, int size) {
+public record CursorRequest(
+        Long key,
+        int size,
+        String name,
+        String location
+) {
     public static final Long NONE_KEY = -2L;
     public static final Long START_KEY = -1L;
 
@@ -9,6 +14,6 @@ public record CursorRequest(Long key, int size) {
     }
 
     public CursorRequest next(Long nextKey) {
-        return new CursorRequest(nextKey, size);
+        return new CursorRequest(nextKey, size, name, location);
     }
 }

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/user/token/ErrorStatus.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/user/token/ErrorStatus.java
@@ -1,0 +1,19 @@
+package com.kakao.sunsuwedding.user.token;
+
+import com.kakao.sunsuwedding._core.errors.BaseException;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorStatus {
+    ACCESS_TOKEN_ALIVE("ACCESS_TOKEN_ALIVE", BaseException.ACCESS_TOKEN_STILL_ALIVE.getMessage()),
+    LOGIN_FAIL("LOGIN_FAIL", BaseException.LOGIN_FAIL.getMessage()),
+    EXPIRED_TOKEN("EXPIRED_TOKEN", BaseException.ACCESS_TOKEN_EXPIRED.getMessage()),
+    MISSING_TOKEN("MISSING_TOKEN", BaseException.TOKEN_NOT_FOUND.getMessage()),
+    INVALID_TOKEN("INVALID_TOKEN", BaseException.TOKEN_NOT_VALID.getMessage()),
+    ALL_TOKEN_EXPIRED("ALL_EXPIRED", BaseException.ALL_TOKEN_EXPIRED.getMessage());
+
+    private final String code;
+    private final String message;
+}

--- a/sunsu-wedding/src/test/java/com/kakao/sunsuwedding/match/MatchRestControllerTest.java
+++ b/sunsu-wedding/src/test/java/com/kakao/sunsuwedding/match/MatchRestControllerTest.java
@@ -59,7 +59,7 @@ public class MatchRestControllerTest {
 
         // then
         result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value("true"));
-        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.chatId").value(1L));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.chatId").value(7L));
     }
 
     @DisplayName("채팅방 생성 실패 테스트 - 이미 존재하는 매칭내역")

--- a/sunsu-wedding/src/test/java/com/kakao/sunsuwedding/match/MatchRestControllerTest.java
+++ b/sunsu-wedding/src/test/java/com/kakao/sunsuwedding/match/MatchRestControllerTest.java
@@ -59,7 +59,7 @@ public class MatchRestControllerTest {
 
         // then
         result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value("true"));
-        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.chatId").value(7L));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.chatId").value(1L));
     }
 
     @DisplayName("채팅방 생성 실패 테스트 - 이미 존재하는 매칭내역")


### PR DESCRIPTION
## 작업 내용
- 포트폴리오 필터링 구현 (쿼리 스트링으로 name=가나다&location=부산 이런 식으로 보내면 됩니다)
- 토큰 관련 에러 응답 양식 변경

## 주의 사항(Optional)
- 테스트를 꼼꼼히 진행하지 않아서 .. 오류 발생하면 말씀해주세요 ㅜㅜ
- 테스트 코드는 다음 주에 작성해서 올려두겠습니다. 먼저 해주셔도 됩니다 !! 다음주에 안올라오면 제가 작성해서 올리도록 하겠습니다

## 이슈 번호
close #99 
close #100 


PR을 두개로 분리해야 했는데  .... 요즘 자꾸 깜빡해서 같이 보냅니다 죄송합니다 ㅜㅜ
🌟 벌써 이슈가 100개를 돌파했습니다 @~@