### PR TITLE
유저 등급에 따른 포트폴리오 거래내역 조회 기능 & 포트폴리오 가격 업데이트 로직 변경

### DIFF
--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioDTOConverter.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioDTOConverter.java
@@ -14,16 +14,27 @@ public class PortfolioDTOConverter {
                                                             Portfolio portfolio,
                                                             List<String> images, List<PriceItem> priceItems,
                                                             List<Match> matches, List<Quotation> quotations) {
+        // 가격 항목 DTO 변환
         List<PortfolioResponse.PriceItemDTO> priceItemDTOS = PriceItemDTOConvertor(priceItems);
-
         Long totalPrice = PriceCalculator.calculatePortfolioPrice(priceItemDTOS);
         PortfolioResponse.PriceDTO priceDTO = new PortfolioResponse.PriceDTO(totalPrice, priceItemDTOS);
 
         // 거래 내역
-        List<PortfolioResponse.PaymentDTO> paymentDTOS = PaymentDTOConvertor(matches, quotations);
-        PortfolioResponse.PaymentHistoryDTO paymentHistoryDTO =
-                new PortfolioResponse.PaymentHistoryDTO(portfolio.getAvgPrice(), portfolio.getMinPrice(),
-                        portfolio.getMaxPrice(), paymentDTOS);
+        // 일반 회원의 경우 거래내역으로 null 반환
+        PortfolioResponse.PaymentHistoryDTO paymentHistoryDTO = null;
+
+        // 프리미엄 회원일 경우 paymentHistory 반환
+        if (!matches.isEmpty() && !quotations.isEmpty()) {
+            List<PortfolioResponse.PaymentDTO> paymentDTOS = PaymentDTOConvertor(matches, quotations);
+            paymentHistoryDTO =
+                    new PortfolioResponse.PaymentHistoryDTO(
+                    portfolio.getAvgPrice(),
+                    portfolio.getMinPrice(),
+                    portfolio.getMaxPrice(),
+                    paymentDTOS
+            );
+        }
+
 
         return FindByIdDTOConvertor(planner, portfolio, images, priceDTO, paymentHistoryDTO);
     }

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioRestController.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioRestController.java
@@ -48,8 +48,9 @@ public class PortfolioRestController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> getPortfolioInDetail(@PathVariable @Min(1) Long id) {
-        PortfolioResponse.FindByIdDTO portfolio = portfolioService.getPortfolioById(id);
+    public ResponseEntity<?> getPortfolioInDetail(@PathVariable @Min(1) Long id,
+                                                  @AuthenticationPrincipal CustomUserDetails userDetails) {
+        PortfolioResponse.FindByIdDTO portfolio = portfolioService.getPortfolioById(id, userDetails.getUser().getId());
         return ResponseEntity.ok().body(ApiUtils.success(portfolio));
     }
 

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
@@ -48,6 +48,7 @@ public class PortfolioService {
     private final PlannerJPARepository plannerJPARepository;
     private final UserJPARepository userJPARepository;
 
+    @Transactional
     public Pair<Portfolio, Planner> addPortfolio(PortfolioRequest.AddDTO request, Long plannerId) {
         // 요청한 플래너 탐색
         Planner planner = plannerJPARepository.findById(plannerId)

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/PortfolioService.java
@@ -223,15 +223,15 @@ public class PortfolioService {
                 .mapToLong(PortfolioRequest.UpdateDTO.ItemDTO::getItemPrice)
                 .sum();
 
-        // 불변 객체 패턴을 고려한 포트폴리오 변경사항 업데이트
+        // 포트폴리오 변경사항 업데이트 객체 생성
         Portfolio updatedPortfolio = Portfolio.builder()
                 .id(portfolio.getId())
                 .planner(planner)
-                .title(request.getTitle() != null ? request.getTitle() : portfolio.getTitle())
-                .description(request.getDescription() != null ? request.getDescription() : portfolio.getDescription())
-                .location(request.getLocation() != null ? request.getLocation() : portfolio.getLocation())
-                .career(request.getCareer() != null ? request.getCareer() : portfolio.getCareer())
-                .partnerCompany(request.getPartnerCompany() != null ? request.getPartnerCompany() : portfolio.getPartnerCompany())
+                .title(request.getTitle())
+                .description(request.getDescription())
+                .location(request.getLocation())
+                .career(request.getCareer())
+                .partnerCompany(request.getPartnerCompany())
                 .totalPrice(totalPrice)
                 .contractCount(portfolio.getContractCount())
                 .avgPrice(portfolio.getAvgPrice())

--- a/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/price/PriceItemJPARepository.java
+++ b/sunsu-wedding/src/main/java/com/kakao/sunsuwedding/portfolio/price/PriceItemJPARepository.java
@@ -2,6 +2,7 @@ package com.kakao.sunsuwedding.portfolio.price;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,5 +17,10 @@ public interface PriceItemJPARepository extends JpaRepository<PriceItem, Long> {
     @EntityGraph("PriceItemWithPortfolioAndPlanner")
     List<PriceItem> findAllByPortfolioId(Long id);
 
+
     void deleteAllByPortfolioPlannerId(Long id);
+
+    @Modifying
+    @Query("delete from PriceItem p where p.portfolio.id = :portfolioId")
+    void deleteAllByPortfolioId(@Param("portfolioId") Long portfolioId);
 }

--- a/sunsu-wedding/src/test/java/com/kakao/sunsuwedding/portfolio/PortfolioControllerTest.java
+++ b/sunsu-wedding/src/test/java/com/kakao/sunsuwedding/portfolio/PortfolioControllerTest.java
@@ -228,9 +228,10 @@ public class PortfolioControllerTest {
 
 
     // ============ 포트폴리오 상세 조회 테스트 ============
-    @DisplayName("포트폴리오 상세 조회 성공 테스트")
+    @DisplayName("포트폴리오 상세 조회 성공 테스트 - 예비부부 (PREMIUM 등급)")
     @Test
-    public void get_portfolio_by_id_success_test() throws Exception {
+    @WithUserDetails("couple2@gmail.com")
+    public void get_portfolio_by_id_premium_success_test() throws Exception {
         //given
         Long id = 1L;
         // when
@@ -252,8 +253,33 @@ public class PortfolioControllerTest {
         result.andExpect(MockMvcResultMatchers.jsonPath("$.response.paymentsHistory.payments[0].confirmedAt").value("2023-10"));
     }
 
+    @DisplayName("포트폴리오 상세 조회 성공 테스트 - 플래너 (NORMAL 등급)")
+    @Test
+    @WithUserDetails("planner0@gmail.com")
+    public void get_portfolio_by_id_normal_success_test() throws Exception {
+        //given
+        Long id = 1L;
+        // when
+        ResultActions result = mockMvc.perform(
+                MockMvcRequestBuilders
+                        .get("/portfolios/{id}", id)
+        );
+
+        String responseBody = result.andReturn().getResponse().getContentAsString();
+        logger.debug("테스트 : " + responseBody);
+
+        // then
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.success").value("true"));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.id").value(1));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.userId").value(2));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.priceInfo.items[0].itemTitle").value("스튜디오1"));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.priceInfo.items[0].itemPrice").value(500000));
+        result.andExpect(MockMvcResultMatchers.jsonPath("$.response.paymentsHistory").isEmpty());
+    }
+
     @DisplayName("포트폴리오 상세 조회 실패 테스트 1 - 존재하지 않는 포트폴리오")
     @Test
+    @WithUserDetails("couple2@gmail.com")
     public void get_portfolio_by_id_fail_test_portfolio_not_found() throws Exception {
         //given
         Long id = 30L;
@@ -274,6 +300,7 @@ public class PortfolioControllerTest {
 
     @DisplayName("포트폴리오 상세 조회 실패 테스트 2 - 탈퇴한 플래너")
     @Test
+    @WithUserDetails("couple2@gmail.com")
     public void get_portfolio_by_id_fail_test_planner_not_found() throws Exception {
         //given
         Long id = 15L; // 탈퇴한 플래너의 포트폴리오 id


### PR DESCRIPTION
기능 구현
- 포트포리오 상세 조회 시, 접근한 유저의 등급에 따른 거래내역 조회
  차별화 기능 구현
- Batch Update에서 Delete 후 Batch Insert로 변경


Bug Fix
- 포트폴리오 추가 기능에 @transactional 어노테이션 추가
- 기존의 포트폴리오 업데이트 객체 생성 시 변경 확인 로직 삭제

close #110 